### PR TITLE
Fix #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+Fixed composable resources being generated twice, and with `Context` context.
 
 ## [0.1.0] - 2022-11-22
 

--- a/catalog-gradle-plugin/src/main/java/com/flaviofaria/catalog/gradle/codegen/writer/CatalogWriter.kt
+++ b/catalog-gradle-plugin/src/main/java/com/flaviofaria/catalog/gradle/codegen/writer/CatalogWriter.kt
@@ -122,7 +122,7 @@ abstract class CatalogWriter<T : ResourceEntry>(
   abstract fun buildExtensionMethod(
     builder: FileSpec.Builder,
     resource: T,
-    contextReceiver: TypeName,
+    contextReceiver: TypeName?,
     asComposeExtensions: Boolean,
   ): FileSpec.Builder
 }

--- a/catalog-gradle-plugin/src/main/java/com/flaviofaria/catalog/gradle/codegen/writer/CatalogWriter.kt
+++ b/catalog-gradle-plugin/src/main/java/com/flaviofaria/catalog/gradle/codegen/writer/CatalogWriter.kt
@@ -64,7 +64,7 @@ abstract class CatalogWriter<T : ResourceEntry>(
             buildExtensionMethod(this, resource, fragmentClass, asComposeExtensions = false)
           }
           if (generateComposeExtensions) {
-            buildExtensionMethod(this, resource, null, asComposeExtensions = true)
+            buildExtensionMethod(this, resource, contextReceiver = null, asComposeExtensions = true)
           }
         }
       }.build()

--- a/catalog-gradle-plugin/src/main/java/com/flaviofaria/catalog/gradle/codegen/writer/CatalogWriter.kt
+++ b/catalog-gradle-plugin/src/main/java/com/flaviofaria/catalog/gradle/codegen/writer/CatalogWriter.kt
@@ -64,8 +64,7 @@ abstract class CatalogWriter<T : ResourceEntry>(
             buildExtensionMethod(this, resource, fragmentClass, asComposeExtensions = false)
           }
           if (generateComposeExtensions) {
-            buildExtensionMethod(this, resource, contextClass, asComposeExtensions = true)
-            buildExtensionMethod(this, resource, fragmentClass, asComposeExtensions = true)
+            buildExtensionMethod(this, resource, null, asComposeExtensions = true)
           }
         }
       }.build()

--- a/catalog-gradle-plugin/src/main/java/com/flaviofaria/catalog/gradle/codegen/writer/StringArrayCatalogWriter.kt
+++ b/catalog-gradle-plugin/src/main/java/com/flaviofaria/catalog/gradle/codegen/writer/StringArrayCatalogWriter.kt
@@ -42,7 +42,7 @@ class StringArrayCatalogWriter(
   override fun buildExtensionMethod(
     builder: FileSpec.Builder,
     resource: ResourceEntry.StringArray,
-    contextReceiver: TypeName,
+    contextReceiver: TypeName?,
     asComposeExtensions: Boolean,
   ): FileSpec.Builder {
     val statementArgs: List<Any>
@@ -66,7 +66,7 @@ class StringArrayCatalogWriter(
           }
         }
         .addModifiers(KModifier.INLINE)
-        .contextReceivers(contextReceiver)
+        .let { b -> contextReceiver?.let { b.contextReceivers(it) } ?: b }
         .receiver(
           if (asComposeExtensions) {
             composeReceiverClass

--- a/catalog-gradle-plugin/src/main/java/com/flaviofaria/catalog/gradle/codegen/writer/StringArrayCatalogWriter.kt
+++ b/catalog-gradle-plugin/src/main/java/com/flaviofaria/catalog/gradle/codegen/writer/StringArrayCatalogWriter.kt
@@ -66,7 +66,7 @@ class StringArrayCatalogWriter(
           }
         }
         .addModifiers(KModifier.INLINE)
-        .let { b -> contextReceiver?.let { b.contextReceivers(it) } ?: b }
+        .apply { contextReceiver?.let { contextReceivers(it) } }
         .receiver(
           if (asComposeExtensions) {
             composeReceiverClass

--- a/catalog-gradle-plugin/src/main/java/com/flaviofaria/catalog/gradle/codegen/writer/WithArgsCatalogWriter.kt
+++ b/catalog-gradle-plugin/src/main/java/com/flaviofaria/catalog/gradle/codegen/writer/WithArgsCatalogWriter.kt
@@ -106,7 +106,7 @@ class WithArgsCatalogWriter(
           }
         }
         .addModifiers(KModifier.INLINE)
-        .let { b -> contextReceiver?.let { b.contextReceivers(it) } ?: b }
+        .apply { contextReceiver?.let { contextReceivers(it) } }
         .receiver(
           if (asComposeExtensions) {
             composeReceiverClass

--- a/catalog-gradle-plugin/src/main/java/com/flaviofaria/catalog/gradle/codegen/writer/WithArgsCatalogWriter.kt
+++ b/catalog-gradle-plugin/src/main/java/com/flaviofaria/catalog/gradle/codegen/writer/WithArgsCatalogWriter.kt
@@ -49,7 +49,7 @@ class WithArgsCatalogWriter(
   override fun buildExtensionMethod(
     builder: FileSpec.Builder,
     resource: ResourceEntry.WithArgs,
-    contextReceiver: TypeName,
+    contextReceiver: TypeName?,
     asComposeExtensions: Boolean,
   ): FileSpec.Builder {
     val sortedArgs = resource.args.sortedBy { it.position }
@@ -106,7 +106,7 @@ class WithArgsCatalogWriter(
           }
         }
         .addModifiers(KModifier.INLINE)
-        .contextReceivers(contextReceiver)
+        .let { b -> contextReceiver?.let { b.contextReceivers(it) } ?: b }
         .receiver(
           if (asComposeExtensions) {
             composeReceiverClass

--- a/catalog-gradle-plugin/src/test/java/com/flaviofaria/catalog/gradle/codegen/writer/StringArrayCatalogWriterTest.kt
+++ b/catalog-gradle-plugin/src/test/java/com/flaviofaria/catalog/gradle/codegen/writer/StringArrayCatalogWriterTest.kt
@@ -181,11 +181,9 @@ class StringArrayCatalogWriterTest {
       |
       |package com.example
       |
-      |import android.content.Context
       |import androidx.compose.runtime.Composable
       |import androidx.compose.runtime.ReadOnlyComposable
       |import androidx.compose.ui.res.stringArrayResource
-      |import androidx.fragment.app.Fragment
       |import com.flaviofaria.catalog.runtime.compose.StringArrays
       |import kotlin.Array
       |import kotlin.Int
@@ -202,16 +200,6 @@ class StringArrayCatalogWriterTest {
       |/**
       | * String array 1 docs
       | */
-      |context(Context)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun StringArrays.stringArray1(): Array<String> =
-      |    stringArrayResource(R.array.string_array_1)
-      |
-      |/**
-      | * String array 1 docs
-      | */
-      |context(Fragment)
       |@Composable
       |@ReadOnlyComposable
       |public inline fun StringArrays.stringArray1(): Array<String> =
@@ -220,13 +208,6 @@ class StringArrayCatalogWriterTest {
       |public inline val StringArrays.stringArray2: Int
       |  get() = R.array.string_array_2
       |
-      |context(Context)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun StringArrays.stringArray2(): Array<String> =
-      |    stringArrayResource(R.array.string_array_2)
-      |
-      |context(Fragment)
       |@Composable
       |@ReadOnlyComposable
       |public inline fun StringArrays.stringArray2(): Array<String> =
@@ -294,16 +275,6 @@ class StringArrayCatalogWriterTest {
       |/**
       | * String array 1 docs
       | */
-      |context(Context)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun StringArrays.stringArray1(): Array<String> =
-      |    stringArrayResource(R.array.string_array_1)
-      |
-      |/**
-      | * String array 1 docs
-      | */
-      |context(Fragment)
       |@Composable
       |@ReadOnlyComposable
       |public inline fun StringArrays.stringArray1(): Array<String> =
@@ -320,13 +291,6 @@ class StringArrayCatalogWriterTest {
       |public inline fun com.flaviofaria.catalog.runtime.resources.StringArrays.stringArray2():
       |    Array<String> = resources.getStringArray(R.array.string_array_2)
       |
-      |context(Context)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun StringArrays.stringArray2(): Array<String> =
-      |    stringArrayResource(R.array.string_array_2)
-      |
-      |context(Fragment)
       |@Composable
       |@ReadOnlyComposable
       |public inline fun StringArrays.stringArray2(): Array<String> =

--- a/catalog-gradle-plugin/src/test/java/com/flaviofaria/catalog/gradle/codegen/writer/WithArgsCatalogWriterTest.kt
+++ b/catalog-gradle-plugin/src/test/java/com/flaviofaria/catalog/gradle/codegen/writer/WithArgsCatalogWriterTest.kt
@@ -533,11 +533,9 @@ class WithArgsCatalogWriterTest {
       |
       |package com.example
       |
-      |import android.content.Context
       |import androidx.compose.runtime.Composable
       |import androidx.compose.runtime.ReadOnlyComposable
       |import androidx.compose.ui.res.stringResource
-      |import androidx.fragment.app.Fragment
       |import com.flaviofaria.catalog.runtime.compose.Strings
       |import kotlin.Char
       |import kotlin.CharSequence
@@ -557,15 +555,6 @@ class WithArgsCatalogWriterTest {
       |/**
       | * String 1 docs
       | */
-      |context(Context)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun Strings.string1(): CharSequence = stringResource(R.string.string_1)
-      |
-      |/**
-      | * String 1 docs
-      | */
-      |context(Fragment)
       |@Composable
       |@ReadOnlyComposable
       |public inline fun Strings.string1(): CharSequence = stringResource(R.string.string_1)
@@ -573,18 +562,6 @@ class WithArgsCatalogWriterTest {
       |public inline val Strings.string2: Int
       |  get() = R.string.string_2
       |
-      |context(Context)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun Strings.string2(
-      |  arg1: Int,
-      |  arg2: Int,
-      |  arg3: UInt,
-      |  arg4: UInt,
-      |  arg5: UInt,
-      |): String = stringResource(R.string.string_2, arg1, arg2, arg3, arg4, arg5)
-      |
-      |context(Fragment)
       |@Composable
       |@ReadOnlyComposable
       |public inline fun Strings.string2(
@@ -598,18 +575,6 @@ class WithArgsCatalogWriterTest {
       |public inline val Strings.string3: Int
       |  get() = R.string.string_3
       |
-      |context(Context)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun Strings.string3(
-      |  arg1: Double,
-      |  arg2: Double,
-      |  arg3: Double,
-      |  arg4: Double,
-      |  arg5: String,
-      |): String = stringResource(R.string.string_3, arg1, arg2, arg3, arg4, arg5)
-      |
-      |context(Fragment)
       |@Composable
       |@ReadOnlyComposable
       |public inline fun Strings.string3(
@@ -623,12 +588,6 @@ class WithArgsCatalogWriterTest {
       |public inline val Strings.string4: Int
       |  get() = R.string.string_4
       |
-      |context(Context)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun Strings.string4(arg1: Char): String = stringResource(R.string.string_4, arg1)
-      |
-      |context(Fragment)
       |@Composable
       |@ReadOnlyComposable
       |public inline fun Strings.string4(arg1: Char): String = stringResource(R.string.string_4, arg1)
@@ -661,12 +620,10 @@ class WithArgsCatalogWriterTest {
       |
       |package com.example
       |
-      |import android.content.Context
       |import androidx.compose.runtime.Composable
       |import androidx.compose.runtime.ReadOnlyComposable
       |import androidx.compose.ui.ExperimentalComposeUiApi
       |import androidx.compose.ui.res.pluralStringResource
-      |import androidx.fragment.app.Fragment
       |import com.flaviofaria.catalog.runtime.compose.Plurals
       |import kotlin.Char
       |import kotlin.CharSequence
@@ -687,17 +644,6 @@ class WithArgsCatalogWriterTest {
       |/**
       | * Plural 1 docs
       | */
-      |context(Context)
-      |@OptIn(ExperimentalComposeUiApi::class)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun Plurals.plural1(quantity: Int): CharSequence =
-      |    pluralStringResource(R.plurals.plural_1, quantity)
-      |
-      |/**
-      | * Plural 1 docs
-      | */
-      |context(Fragment)
       |@OptIn(ExperimentalComposeUiApi::class)
       |@Composable
       |@ReadOnlyComposable
@@ -707,20 +653,6 @@ class WithArgsCatalogWriterTest {
       |public inline val Plurals.plural2: Int
       |  get() = R.plurals.plural_2
       |
-      |context(Context)
-      |@OptIn(ExperimentalComposeUiApi::class)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun Plurals.plural2(
-      |  quantity: Int,
-      |  arg1: Int,
-      |  arg2: Int,
-      |  arg3: UInt,
-      |  arg4: UInt,
-      |  arg5: UInt,
-      |): String = pluralStringResource(R.plurals.plural_2, quantity, arg1, arg2, arg3, arg4, arg5)
-      |
-      |context(Fragment)
       |@OptIn(ExperimentalComposeUiApi::class)
       |@Composable
       |@ReadOnlyComposable
@@ -736,20 +668,6 @@ class WithArgsCatalogWriterTest {
       |public inline val Plurals.plural3: Int
       |  get() = R.plurals.plural_3
       |
-      |context(Context)
-      |@OptIn(ExperimentalComposeUiApi::class)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun Plurals.plural3(
-      |  quantity: Int,
-      |  arg1: Double,
-      |  arg2: Double,
-      |  arg3: Double,
-      |  arg4: Double,
-      |  arg5: String,
-      |): String = pluralStringResource(R.plurals.plural_3, quantity, arg1, arg2, arg3, arg4, arg5)
-      |
-      |context(Fragment)
       |@OptIn(ExperimentalComposeUiApi::class)
       |@Composable
       |@ReadOnlyComposable
@@ -765,14 +683,6 @@ class WithArgsCatalogWriterTest {
       |public inline val Plurals.plural4: Int
       |  get() = R.plurals.plural_4
       |
-      |context(Context)
-      |@OptIn(ExperimentalComposeUiApi::class)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun Plurals.plural4(quantity: Int, arg1: Char): String =
-      |    pluralStringResource(R.plurals.plural_4, quantity, arg1)
-      |
-      |context(Fragment)
       |@OptIn(ExperimentalComposeUiApi::class)
       |@Composable
       |@ReadOnlyComposable
@@ -845,15 +755,6 @@ class WithArgsCatalogWriterTest {
       |/**
       | * String 1 docs
       | */
-      |context(Context)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun Strings.string1(): CharSequence = stringResource(R.string.string_1)
-      |
-      |/**
-      | * String 1 docs
-      | */
-      |context(Fragment)
       |@Composable
       |@ReadOnlyComposable
       |public inline fun Strings.string1(): CharSequence = stringResource(R.string.string_1)
@@ -879,18 +780,6 @@ class WithArgsCatalogWriterTest {
       |  arg5: UInt,
       |): String = getString(R.string.string_2, arg1, arg2, arg3, arg4, arg5)
       |
-      |context(Context)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun Strings.string2(
-      |  arg1: Int,
-      |  arg2: Int,
-      |  arg3: UInt,
-      |  arg4: UInt,
-      |  arg5: UInt,
-      |): String = stringResource(R.string.string_2, arg1, arg2, arg3, arg4, arg5)
-      |
-      |context(Fragment)
       |@Composable
       |@ReadOnlyComposable
       |public inline fun Strings.string2(
@@ -922,18 +811,6 @@ class WithArgsCatalogWriterTest {
       |  arg5: String,
       |): String = getString(R.string.string_3, arg1, arg2, arg3, arg4, arg5)
       |
-      |context(Context)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun Strings.string3(
-      |  arg1: Double,
-      |  arg2: Double,
-      |  arg3: Double,
-      |  arg4: Double,
-      |  arg5: String,
-      |): String = stringResource(R.string.string_3, arg1, arg2, arg3, arg4, arg5)
-      |
-      |context(Fragment)
       |@Composable
       |@ReadOnlyComposable
       |public inline fun Strings.string3(
@@ -955,12 +832,6 @@ class WithArgsCatalogWriterTest {
       |public inline fun com.flaviofaria.catalog.runtime.resources.Strings.string4(arg1: Char): String =
       |    getString(R.string.string_4, arg1)
       |
-      |context(Context)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun Strings.string4(arg1: Char): String = stringResource(R.string.string_4, arg1)
-      |
-      |context(Fragment)
       |@Composable
       |@ReadOnlyComposable
       |public inline fun Strings.string4(arg1: Char): String = stringResource(R.string.string_4, arg1)
@@ -1033,17 +904,6 @@ class WithArgsCatalogWriterTest {
       |/**
       | * Plural 1 docs
       | */
-      |context(Context)
-      |@OptIn(ExperimentalComposeUiApi::class)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun Plurals.plural1(quantity: Int): CharSequence =
-      |    pluralStringResource(R.plurals.plural_1, quantity)
-      |
-      |/**
-      | * Plural 1 docs
-      | */
-      |context(Fragment)
       |@OptIn(ExperimentalComposeUiApi::class)
       |@Composable
       |@ReadOnlyComposable
@@ -1073,20 +933,6 @@ class WithArgsCatalogWriterTest {
       |  arg5: UInt,
       |): String = resources.getQuantityString(R.plurals.plural_2, quantity, arg1, arg2, arg3, arg4, arg5)
       |
-      |context(Context)
-      |@OptIn(ExperimentalComposeUiApi::class)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun Plurals.plural2(
-      |  quantity: Int,
-      |  arg1: Int,
-      |  arg2: Int,
-      |  arg3: UInt,
-      |  arg4: UInt,
-      |  arg5: UInt,
-      |): String = pluralStringResource(R.plurals.plural_2, quantity, arg1, arg2, arg3, arg4, arg5)
-      |
-      |context(Fragment)
       |@OptIn(ExperimentalComposeUiApi::class)
       |@Composable
       |@ReadOnlyComposable
@@ -1122,20 +968,6 @@ class WithArgsCatalogWriterTest {
       |  arg5: String,
       |): String = resources.getQuantityString(R.plurals.plural_3, quantity, arg1, arg2, arg3, arg4, arg5)
       |
-      |context(Context)
-      |@OptIn(ExperimentalComposeUiApi::class)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun Plurals.plural3(
-      |  quantity: Int,
-      |  arg1: Double,
-      |  arg2: Double,
-      |  arg3: Double,
-      |  arg4: Double,
-      |  arg5: String,
-      |): String = pluralStringResource(R.plurals.plural_3, quantity, arg1, arg2, arg3, arg4, arg5)
-      |
-      |context(Fragment)
       |@OptIn(ExperimentalComposeUiApi::class)
       |@Composable
       |@ReadOnlyComposable
@@ -1159,14 +991,6 @@ class WithArgsCatalogWriterTest {
       |public inline fun com.flaviofaria.catalog.runtime.resources.Plurals.plural4(quantity: Int,
       |    arg1: Char): String = resources.getQuantityString(R.plurals.plural_4, quantity, arg1)
       |
-      |context(Context)
-      |@OptIn(ExperimentalComposeUiApi::class)
-      |@Composable
-      |@ReadOnlyComposable
-      |public inline fun Plurals.plural4(quantity: Int, arg1: Char): String =
-      |    pluralStringResource(R.plurals.plural_4, quantity, arg1)
-      |
-      |context(Fragment)
       |@OptIn(ExperimentalComposeUiApi::class)
       |@Composable
       |@ReadOnlyComposable


### PR DESCRIPTION
Before this change, when generating composables for example:
```xml
<string name="welcome">Welcome back!</string>
```
Duplicates were made:
```kotlin
context(Context)
@Composable
@ReadOnlyComposable
public inline fun Strings.welcome(): CharSequence = stringResource(R.string.welcome)

context(Fragment)
@Composable
@ReadOnlyComposable
public inline fun Strings.welcome(): CharSequence = stringResource(R.string.welcome)
```
After:
```kotlin
@Composable
@ReadOnlyComposable
public inline fun Strings.welcome(): CharSequence = stringResource(R.string.welcome)
```